### PR TITLE
restore errata page CSS into dedicated stylesheet

### DIFF
--- a/src/assets/css/errata.css
+++ b/src/assets/css/errata.css
@@ -1,0 +1,128 @@
+/* Errata page — kintsugi-styled corrections */
+
+.errata {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 var(--space-md);
+    line-height: 1.7;
+}
+
+.errata-header {
+    margin-bottom: var(--space-xl);
+}
+
+.errata-back {
+    color: var(--color-accent);
+    text-decoration: none;
+    margin-bottom: var(--space-md);
+    display: inline-block;
+}
+
+.errata h1 {
+    font-size: 2rem;
+    margin-bottom: var(--space-md);
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+}
+
+.errata-subtitle {
+    font-size: 1.1rem;
+    color: var(--color-text-secondary);
+    margin-bottom: var(--space-lg);
+}
+
+/* Kintsugi bowl figure */
+.errata-figure {
+    margin: 0 0 var(--space-xxl) 0;
+    text-align: center;
+}
+.errata-figure img {
+    max-width: 100%;
+    border-radius: var(--border-radius);
+    image-rendering: auto;
+}
+.errata-figure figcaption {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    margin-top: var(--space-sm);
+    line-height: 1.5;
+}
+
+/* Sections */
+.errata section {
+    margin-bottom: var(--space-xxl);
+}
+.errata section p {
+    margin-bottom: var(--space-md);
+}
+
+.errata h2 {
+    font-size: 1.3rem;
+    margin-bottom: var(--space-md);
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+}
+
+.errata h3 {
+    font-size: 1.1rem;
+    margin-bottom: var(--space-sm);
+    margin-top: var(--space-lg);
+    color: var(--color-text-primary);
+    font-weight: 600;
+}
+
+.errata-category-desc {
+    margin-bottom: var(--space-sm);
+    font-size: 0.9rem;
+    color: var(--color-text-secondary);
+}
+
+/* Correction diff boxes */
+.errata-diff {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    padding: var(--space-md);
+    margin-bottom: var(--space-lg);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    overflow-x: auto;
+}
+.errata-diff > div {
+    margin-bottom: var(--space-sm);
+}
+.errata-diff > div:last-child {
+    margin-bottom: 0;
+}
+
+/* Inline/block correction pairs for filler-phrase style diffs */
+.errata-diff .errata-block {
+    margin-bottom: var(--space-md);
+}
+.errata-diff .errata-block:last-child {
+    margin-bottom: 0;
+}
+
+/* Struck-out old text (zenburn red) */
+.errata-old {
+    color: #cc9393;
+    text-decoration: line-through;
+}
+
+/* Replacement text (zenburn green) */
+.errata-new {
+    color: #7f9f7f;
+}
+
+/* Arrow separator */
+.errata-arrow {
+    color: var(--color-text-secondary);
+}
+
+/* Footer links */
+.errata-footer {
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+    border-top: 1px solid var(--color-border);
+    padding-top: var(--space-md);
+}

--- a/src/assets/css/errata.css
+++ b/src/assets/css/errata.css
@@ -1,4 +1,8 @@
-/* Errata page — kintsugi-styled corrections */
+/* Errata page — kintsugi-styled corrections
+ *
+ * Restoration of the original human-edit / diff / hotswap CSS
+ * from the pre-Eleventy globals.css, adapted for the kintsugi framing.
+ */
 
 .errata {
     max-width: 800px;
@@ -77,49 +81,110 @@
     color: var(--color-text-secondary);
 }
 
-/* Correction diff boxes */
+/* ── Correction diff boxes ─────────────────────────────────────────── */
 .errata-diff {
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
+    border: 1px solid #4a4a4a;
     border-radius: var(--border-radius);
-    padding: var(--space-md);
     margin-bottom: var(--space-lg);
+    background-color: var(--color-surface);
     font-family: var(--font-mono);
     font-size: 0.85rem;
     overflow-x: auto;
 }
-.errata-diff > div {
+.errata-diff-header {
+    background-color: #2a2a2a;
+    padding: var(--space-sm) var(--space-md);
+    border-bottom: 1px solid #4a4a4a;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: #7f9f7f;
+    font-weight: 600;
+}
+.errata-diff-content {
+    padding: var(--space-md);
+    line-height: 1.5;
+}
+
+/* Single-line arrow diffs  (old → new) */
+.errata-diff-content > div {
     margin-bottom: var(--space-sm);
 }
-.errata-diff > div:last-child {
+.errata-diff-content > div:last-child {
     margin-bottom: 0;
 }
 
-/* Inline/block correction pairs for filler-phrase style diffs */
-.errata-diff .errata-block {
-    margin-bottom: var(--space-md);
+/* Block diffs — before / after on separate lines */
+.errata-block {
+    margin-bottom: var(--space-sm);
 }
-.errata-diff .errata-block:last-child {
+.errata-block:last-child {
     margin-bottom: 0;
 }
 
-/* Struck-out old text (zenburn red) */
+/* Removed text — red tint, line-through, red left border */
+.diff-removed {
+    background-color: #2d1b1b;
+    color: #ff9999;
+    padding: 0.1rem 0.2rem;
+    margin: 0.1rem 0;
+    border-left: 3px solid #cc6666;
+    display: block;
+    text-decoration: line-through;
+    opacity: 0.8;
+}
+
+/* Added text — green tint, green left border */
+.diff-added {
+    background-color: #1b2d1b;
+    color: #99ff99;
+    padding: 0.1rem 0.2rem;
+    margin: 0.1rem 0;
+    border-left: 3px solid #7f9f7f;
+    display: block;
+    font-weight: 500;
+}
+
+/* Inline old/new spans for arrow-style diffs */
 .errata-old {
     color: #cc9393;
     text-decoration: line-through;
 }
-
-/* Replacement text (zenburn green) */
 .errata-new {
     color: #7f9f7f;
 }
-
-/* Arrow separator */
 .errata-arrow {
     color: var(--color-text-secondary);
 }
 
-/* Footer links */
+/* ── Human-edit highlights (reusable across the site) ──────────────── */
+.human-edit {
+    background-color: #000000;
+    color: #ffffff;
+    padding: 0.125rem 0.25rem;
+    border-radius: 2px;
+    font-weight: 500;
+    border: 1px solid #333333;
+}
+.human-edit-subtle {
+    background-color: #2a2a2a;
+    color: #dcdccc;
+    padding: 0.125rem 0.25rem;
+    border-radius: 2px;
+    border-left: 3px solid #7f9f7f;
+}
+.human-edit-inline {
+    background-color: #1a1a1a;
+    color: #ffffff;
+    padding: 0.0625rem 0.1875rem;
+    border-radius: 1px;
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: #7f9f7f;
+    text-decoration-style: solid;
+    text-underline-offset: 2px;
+}
+
+/* ── Footer links ──────────────────────────────────────────────────── */
 .errata-footer {
     font-size: 0.85rem;
     color: var(--color-text-secondary);

--- a/src/errata.html
+++ b/src/errata.html
@@ -2,164 +2,149 @@
 layout: base.njk
 title: Errata - qry.zone
 description: Showing the repairs — a kintsugi approach to corrections
+extraStyles: |
+  <link rel="stylesheet" href="/assets/css/errata.css">
 ---
 
-<article class="article">
-  <div style="max-width: 800px; margin: 0 auto; padding: 0 var(--space-md); line-height: 1.7">
+<article class="article errata">
 
-    <div style="margin-bottom: var(--space-xl)">
-      <a href="/explore/" style="color: var(--color-accent); text-decoration: none; margin-bottom: var(--space-md); display: inline-block">
+    <div class="errata-header">
+      <a href="/explore/" class="errata-back">
         &larr; Back to Explore
       </a>
       <span class="status-badge status-growing">growing</span>
-      <h1 style="font-size: 2rem; margin-bottom: var(--space-md); color: var(--color-accent); font-family: var(--font-mono)">
-        Errata
-      </h1>
-      <p style="font-size: 1.1rem; color: var(--color-text-secondary); margin-bottom: var(--space-lg)">
+      <h1>Errata</h1>
+      <p class="errata-subtitle">
         Showing the repairs.
       </p>
     </div>
 
-    <figure style="margin: 0 0 var(--space-xxl) 0; text-align: center;">
+    <figure class="errata-figure">
       <img
         src="/assets/images/kintsugi-bowl.png"
         alt="A kintsugi tea bowl with golden repair lines visible along cracks, dithered in zenburn palette"
-        style="max-width: 100%; border-radius: var(--border-radius); image-rendering: auto;"
       >
-      <figcaption style="font-size: 0.75rem; color: var(--color-text-secondary); margin-top: var(--space-sm); line-height: 1.5;">
-        By <a href="https://www.flickr.com/people/72746018@N00" style="color: var(--color-accent);" rel="nofollow">Jean-Pierre Dalb&eacute;ra</a> &mdash;
-        <a href="https://www.flickr.com/photos/dalbera/54477114579/" style="color: var(--color-accent);" rel="nofollow">Bol &agrave; th&eacute; (Maison de la Culture du Japon, Paris)</a>,
-        <a href="https://creativecommons.org/licenses/by/2.0" style="color: var(--color-accent);">CC BY 2.0</a>.
+      <figcaption>
+        By <a href="https://www.flickr.com/people/72746018@N00" rel="nofollow">Jean-Pierre Dalb&eacute;ra</a> &mdash;
+        <a href="https://www.flickr.com/photos/dalbera/54477114579/" rel="nofollow">Bol &agrave; th&eacute; (Maison de la Culture du Japon, Paris)</a>,
+        <a href="https://creativecommons.org/licenses/by/2.0">CC BY 2.0</a>.
         Dithered with Atkinson algorithm in zenburn palette.
       </figcaption>
     </figure>
 
-    <section style="margin-bottom: var(--space-xxl)">
-      <p style="margin-bottom: var(--space-md)">
+    <section>
+      <p>
         Kintsugi fills cracks with gold instead of hiding them. The repair becomes part of the object's history. The bowl is more interesting for having broken.
       </p>
 
-      <p style="margin-bottom: var(--space-md)">
+      <p>
         This site is written with AI assistance and then edited by hand. Sometimes the edits happen on publication day. Sometimes months later, when a word that seemed fine starts to grate. The corrections below are the gold lines &mdash; visible repairs where something was wrong and got fixed.
       </p>
 
-      <p style="margin-bottom: var(--space-md)">
-        Most of these are <a href="/antislop-editorial/" style="color: var(--color-accent);">de-slopping</a> passes: replacing words and patterns that leak through AI-assisted drafting. Vague headings that gesture at meaning without providing it. Filler phrases that pad sentences. Overused words that make everything sound the same.
+      <p>
+        Most of these are <a href="/antislop-editorial/">de-slopping</a> passes: replacing words and patterns that leak through AI-assisted drafting. Vague headings that gesture at meaning without providing it. Filler phrases that pad sentences. Overused words that make everything sound the same.
       </p>
     </section>
 
-    <section style="margin-bottom: var(--space-xxl)">
-      <h2 style="font-size: 1.3rem; margin-bottom: var(--space-md); color: var(--color-accent); font-family: var(--font-mono)">
+    <section>
+      <h2>
         February 2026 &mdash; the big pass
       </h2>
-      <p style="margin-bottom: var(--space-md)">
-        37 files. 150 lines changed. After building the <a href="/slopsquid-technical-preset/" style="color: var(--color-accent);">SlopSquid technical preset</a>
-        and writing about <a href="/antislop-editorial/" style="color: var(--color-accent);">de-slopping in practice</a>,
+      <p>
+        37 files. 150 lines changed. After building the <a href="/slopsquid-technical-preset/">SlopSquid technical preset</a>
+        and writing about <a href="/antislop-editorial/">de-slopping in practice</a>,
         it felt dishonest not to turn the detector on the rest of the site. Here's what it found.
       </p>
 
-      <h3 style="font-size: 1.1rem; margin-bottom: var(--space-sm); margin-top: var(--space-lg); color: var(--color-text-primary); font-weight: 600">
-        Vague headings replaced with specific ones
-      </h3>
-      <p style="margin-bottom: var(--space-sm); font-size: 0.9rem; color: var(--color-text-secondary)">
+      <h3>Vague headings replaced with specific ones</h3>
+      <p class="errata-category-desc">
         Headings that gesture at structure without telling you what's in the section.
       </p>
-      <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--border-radius); padding: var(--space-md); margin-bottom: var(--space-lg); font-family: var(--font-mono); font-size: 0.85rem; overflow-x: auto;">
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">The gap</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">Existing text, no GPU</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">What we found</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">Twelve edits in one article</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">The tool</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">SlopSquid</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">The tension</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">Hard bans break writing</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">Where this goes</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">Beyond fiction banlists</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">The meta layer</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">Even the critique gets commodified</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">What this changes</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">So what do you do</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">What convergent evolution tells us</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">Same pressure, same shape</span></div>
-        <div><span style="color: #cc9393; text-decoration: line-through;">Design Deep Dive</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">Design Document</span></div>
+      <div class="errata-diff">
+        <div><span class="errata-old">The gap</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Existing text, no GPU</span></div>
+        <div><span class="errata-old">What we found</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Twelve edits in one article</span></div>
+        <div><span class="errata-old">The tool</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">SlopSquid</span></div>
+        <div><span class="errata-old">The tension</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Hard bans break writing</span></div>
+        <div><span class="errata-old">Where this goes</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Beyond fiction banlists</span></div>
+        <div><span class="errata-old">The meta layer</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Even the critique gets commodified</span></div>
+        <div><span class="errata-old">What this changes</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">So what do you do</span></div>
+        <div><span class="errata-old">What convergent evolution tells us</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Same pressure, same shape</span></div>
+        <div><span class="errata-old">Design Deep Dive</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Design Document</span></div>
       </div>
 
-      <h3 style="font-size: 1.1rem; margin-bottom: var(--space-sm); margin-top: var(--space-lg); color: var(--color-text-primary); font-weight: 600">
-        Overused words
-      </h3>
-      <p style="margin-bottom: var(--space-sm); font-size: 0.9rem; color: var(--color-text-secondary)">
+      <h3>Overused words</h3>
+      <p class="errata-category-desc">
         Words that AI reaches for when a more specific one exists. Each appeared multiple times across the site.
       </p>
-      <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--border-radius); padding: var(--space-md); margin-bottom: var(--space-lg); font-family: var(--font-mono); font-size: 0.85rem; overflow-x: auto;">
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">landscape</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">market, space</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">ecosystem</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">toolset, toolchain, stack, portfolio</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">comprehensive</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">complete, full</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">crucial</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">key, important</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">seamless</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">smooth</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">nuanced</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">detailed</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">fundamental</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">underlying</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">leveraging, leans on</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">using, relies on</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">streamline</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">simplify</span></div>
-        <div><span style="color: #cc9393; text-decoration: line-through;">remarkable</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">(removed)</span></div>
+      <div class="errata-diff">
+        <div><span class="errata-old">landscape</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">market, space</span></div>
+        <div><span class="errata-old">ecosystem</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">toolset, toolchain, stack, portfolio</span></div>
+        <div><span class="errata-old">comprehensive</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">complete, full</span></div>
+        <div><span class="errata-old">crucial</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">key, important</span></div>
+        <div><span class="errata-old">seamless</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">smooth</span></div>
+        <div><span class="errata-old">nuanced</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">detailed</span></div>
+        <div><span class="errata-old">fundamental</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">underlying</span></div>
+        <div><span class="errata-old">leveraging, leans on</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">using, relies on</span></div>
+        <div><span class="errata-old">streamline</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">simplify</span></div>
+        <div><span class="errata-old">remarkable</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">(removed)</span></div>
       </div>
 
-      <h3 style="font-size: 1.1rem; margin-bottom: var(--space-sm); margin-top: var(--space-lg); color: var(--color-text-primary); font-weight: 600">
-        Filler phrases cut
-      </h3>
-      <p style="margin-bottom: var(--space-sm); font-size: 0.9rem; color: var(--color-text-secondary)">
+      <h3>Filler phrases cut</h3>
+      <p class="errata-category-desc">
         Throat-clearing that delays the point. The sentence works better without it.
       </p>
-      <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--border-radius); padding: var(--space-md); margin-bottom: var(--space-lg); font-family: var(--font-mono); font-size: 0.85rem; overflow-x: auto;">
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">Turns out this isn't just a feeling. It's statistically measurable.</span></div>
-        <div style="margin-bottom: var(--space-md);"><span style="color: #7f9f7f;">Turns out this is statistically measurable.</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">Here's where it gets interesting. Each of these parallels...</span></div>
-        <div style="margin-bottom: var(--space-md);"><span style="color: #7f9f7f;">Each of these parallels...</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">This isn't just visual flourish &mdash; it's a direct representation of...</span></div>
-        <div style="margin-bottom: var(--space-md);"><span style="color: #7f9f7f;">&mdash; a direct representation of...</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">Acknowledging economic constraints isn't defeat. It's starting from reality...</span></div>
-        <div style="margin-bottom: var(--space-md);"><span style="color: #7f9f7f;">Acknowledging economic constraints means starting from reality...</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">The goal isn't to predict the future perfectly, but to position for multiple possible futures...</span></div>
-        <div><span style="color: #7f9f7f;">The goal is to position for multiple possible futures...</span></div>
+      <div class="errata-diff">
+        <div class="errata-block"><div><span class="errata-old">Turns out this isn't just a feeling. It's statistically measurable.</span></div>
+        <div><span class="errata-new">Turns out this is statistically measurable.</span></div></div>
+        <div class="errata-block"><div><span class="errata-old">Here's where it gets interesting. Each of these parallels...</span></div>
+        <div><span class="errata-new">Each of these parallels...</span></div></div>
+        <div class="errata-block"><div><span class="errata-old">This isn't just visual flourish &mdash; it's a direct representation of...</span></div>
+        <div><span class="errata-new">&mdash; a direct representation of...</span></div></div>
+        <div class="errata-block"><div><span class="errata-old">Acknowledging economic constraints isn't defeat. It's starting from reality...</span></div>
+        <div><span class="errata-new">Acknowledging economic constraints means starting from reality...</span></div></div>
+        <div class="errata-block"><div><span class="errata-old">The goal isn't to predict the future perfectly, but to position for multiple possible futures...</span></div>
+        <div><span class="errata-new">The goal is to position for multiple possible futures...</span></div></div>
       </div>
 
-      <h3 style="font-size: 1.1rem; margin-bottom: var(--space-sm); margin-top: var(--space-lg); color: var(--color-text-primary); font-weight: 600">
-        The "isn't X, it's Y" pattern
-      </h3>
-      <p style="margin-bottom: var(--space-sm); font-size: 0.9rem; color: var(--color-text-secondary)">
+      <h3>The "isn't X, it's Y" pattern</h3>
+      <p class="errata-category-desc">
         AI loves this construction. It sounds clever and says the same thing twice.
       </p>
-      <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--border-radius); padding: var(--space-md); margin-bottom: var(--space-lg); font-family: var(--font-mono); font-size: 0.85rem; overflow-x: auto;">
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">it's not trying to be a manifesto. It's trying to be useful.</span></div>
-        <div style="margin-bottom: var(--space-md);"><span style="color: #7f9f7f;">it's pragmatic rather than ideological.</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">That's not hypocrisy &mdash; it's just the water we swim in.</span></div>
-        <div style="margin-bottom: var(--space-md);"><span style="color: #7f9f7f;">Call it hypocrisy if you want &mdash; it's just the water we swim in.</span></div>
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">This isn't about AI dependency or replacement of human capability. It's about specific cognitive patterns...</span></div>
-        <div><span style="color: #7f9f7f;">The key factor is specific cognitive patterns...</span></div>
+      <div class="errata-diff">
+        <div class="errata-block"><div><span class="errata-old">it's not trying to be a manifesto. It's trying to be useful.</span></div>
+        <div><span class="errata-new">it's pragmatic rather than ideological.</span></div></div>
+        <div class="errata-block"><div><span class="errata-old">That's not hypocrisy &mdash; it's just the water we swim in.</span></div>
+        <div><span class="errata-new">Call it hypocrisy if you want &mdash; it's just the water we swim in.</span></div></div>
+        <div class="errata-block"><div><span class="errata-old">This isn't about AI dependency or replacement of human capability. It's about specific cognitive patterns...</span></div>
+        <div><span class="errata-new">The key factor is specific cognitive patterns...</span></div></div>
       </div>
 
-      <h3 style="font-size: 1.1rem; margin-bottom: var(--space-sm); margin-top: var(--space-lg); color: var(--color-text-primary); font-weight: 600">
-        The "fascinating" problem
-      </h3>
-      <p style="margin-bottom: var(--space-sm); font-size: 0.9rem; color: var(--color-text-secondary)">
+      <h3>The "fascinating" problem</h3>
+      <p class="errata-category-desc">
         If it's fascinating, the reader will figure that out. You don't need to announce it.
       </p>
-      <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--border-radius); padding: var(--space-md); margin-bottom: var(--space-lg); font-family: var(--font-mono); font-size: 0.85rem; overflow-x: auto;">
-        <div style="margin-bottom: var(--space-sm);"><span style="color: #cc9393; text-decoration: line-through;">creates a fascinating strategic tension</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">creates a strategic tension</span></div>
-        <div><span style="color: #cc9393; text-decoration: line-through;">A remarkable periodic solution</span> <span style="color: var(--color-text-secondary);">&rarr;</span> <span style="color: #7f9f7f;">A periodic solution</span></div>
+      <div class="errata-diff">
+        <div><span class="errata-old">creates a fascinating strategic tension</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">creates a strategic tension</span></div>
+        <div><span class="errata-old">A remarkable periodic solution</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">A periodic solution</span></div>
       </div>
     </section>
 
-    <section style="margin-bottom: var(--space-xxl)">
-      <h2 style="font-size: 1.3rem; margin-bottom: var(--space-md); color: var(--color-accent); font-family: var(--font-mono)">
-        Why publish this
-      </h2>
-      <p style="margin-bottom: var(--space-md)">
+    <section>
+      <h2>Why publish this</h2>
+      <p>
         Writing with AI means accepting that some percentage of what gets published will have a machine fingerprint on it. You can pretend otherwise, or you can make the corrections visible. The repairs are the proof you're paying attention.
       </p>
-      <p style="margin-bottom: var(--space-md)">
+      <p>
         This page will grow as more corrections happen. That's the point. A site that never needs corrections either isn't being read or isn't being honest.
       </p>
     </section>
 
-    <div style="font-size: 0.85rem; color: var(--color-text-secondary); border-top: 1px solid var(--color-border); padding-top: var(--space-md);">
+    <div class="errata-footer">
       <p>
-        See also: <a href="/antislop-editorial/" style="color: var(--color-accent);">De-slopping in practice</a> &middot;
-        <a href="/slopsquid-technical-preset/" style="color: var(--color-accent);">Tuning the detector</a> &middot;
-        <a href="/styleguide/" style="color: var(--color-accent);">Writing styleguide</a>
+        See also: <a href="/antislop-editorial/">De-slopping in practice</a> &middot;
+        <a href="/slopsquid-technical-preset/">Tuning the detector</a> &middot;
+        <a href="/styleguide/">Writing styleguide</a>
       </p>
     </div>
 
-  </div>
 </article>

--- a/src/errata.html
+++ b/src/errata.html
@@ -61,15 +61,18 @@ extraStyles: |
         Headings that gesture at structure without telling you what's in the section.
       </p>
       <div class="errata-diff">
-        <div><span class="errata-old">The gap</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Existing text, no GPU</span></div>
-        <div><span class="errata-old">What we found</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Twelve edits in one article</span></div>
-        <div><span class="errata-old">The tool</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">SlopSquid</span></div>
-        <div><span class="errata-old">The tension</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Hard bans break writing</span></div>
-        <div><span class="errata-old">Where this goes</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Beyond fiction banlists</span></div>
-        <div><span class="errata-old">The meta layer</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Even the critique gets commodified</span></div>
-        <div><span class="errata-old">What this changes</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">So what do you do</span></div>
-        <div><span class="errata-old">What convergent evolution tells us</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Same pressure, same shape</span></div>
-        <div><span class="errata-old">Design Deep Dive</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Design Document</span></div>
+        <div class="errata-diff-header">headings &rarr; specifics</div>
+        <div class="errata-diff-content">
+          <div><span class="errata-old">The gap</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Existing text, no GPU</span></div>
+          <div><span class="errata-old">What we found</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Twelve edits in one article</span></div>
+          <div><span class="errata-old">The tool</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">SlopSquid</span></div>
+          <div><span class="errata-old">The tension</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Hard bans break writing</span></div>
+          <div><span class="errata-old">Where this goes</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Beyond fiction banlists</span></div>
+          <div><span class="errata-old">The meta layer</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Even the critique gets commodified</span></div>
+          <div><span class="errata-old">What this changes</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">So what do you do</span></div>
+          <div><span class="errata-old">What convergent evolution tells us</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Same pressure, same shape</span></div>
+          <div><span class="errata-old">Design Deep Dive</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">Design Document</span></div>
+        </div>
       </div>
 
       <h3>Overused words</h3>
@@ -77,16 +80,19 @@ extraStyles: |
         Words that AI reaches for when a more specific one exists. Each appeared multiple times across the site.
       </p>
       <div class="errata-diff">
-        <div><span class="errata-old">landscape</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">market, space</span></div>
-        <div><span class="errata-old">ecosystem</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">toolset, toolchain, stack, portfolio</span></div>
-        <div><span class="errata-old">comprehensive</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">complete, full</span></div>
-        <div><span class="errata-old">crucial</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">key, important</span></div>
-        <div><span class="errata-old">seamless</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">smooth</span></div>
-        <div><span class="errata-old">nuanced</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">detailed</span></div>
-        <div><span class="errata-old">fundamental</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">underlying</span></div>
-        <div><span class="errata-old">leveraging, leans on</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">using, relies on</span></div>
-        <div><span class="errata-old">streamline</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">simplify</span></div>
-        <div><span class="errata-old">remarkable</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">(removed)</span></div>
+        <div class="errata-diff-header">word replacements</div>
+        <div class="errata-diff-content">
+          <div><span class="errata-old">landscape</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">market, space</span></div>
+          <div><span class="errata-old">ecosystem</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">toolset, toolchain, stack, portfolio</span></div>
+          <div><span class="errata-old">comprehensive</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">complete, full</span></div>
+          <div><span class="errata-old">crucial</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">key, important</span></div>
+          <div><span class="errata-old">seamless</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">smooth</span></div>
+          <div><span class="errata-old">nuanced</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">detailed</span></div>
+          <div><span class="errata-old">fundamental</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">underlying</span></div>
+          <div><span class="errata-old">leveraging, leans on</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">using, relies on</span></div>
+          <div><span class="errata-old">streamline</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">simplify</span></div>
+          <div><span class="errata-old">remarkable</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">(removed)</span></div>
+        </div>
       </div>
 
       <h3>Filler phrases cut</h3>
@@ -94,16 +100,29 @@ extraStyles: |
         Throat-clearing that delays the point. The sentence works better without it.
       </p>
       <div class="errata-diff">
-        <div class="errata-block"><div><span class="errata-old">Turns out this isn't just a feeling. It's statistically measurable.</span></div>
-        <div><span class="errata-new">Turns out this is statistically measurable.</span></div></div>
-        <div class="errata-block"><div><span class="errata-old">Here's where it gets interesting. Each of these parallels...</span></div>
-        <div><span class="errata-new">Each of these parallels...</span></div></div>
-        <div class="errata-block"><div><span class="errata-old">This isn't just visual flourish &mdash; it's a direct representation of...</span></div>
-        <div><span class="errata-new">&mdash; a direct representation of...</span></div></div>
-        <div class="errata-block"><div><span class="errata-old">Acknowledging economic constraints isn't defeat. It's starting from reality...</span></div>
-        <div><span class="errata-new">Acknowledging economic constraints means starting from reality...</span></div></div>
-        <div class="errata-block"><div><span class="errata-old">The goal isn't to predict the future perfectly, but to position for multiple possible futures...</span></div>
-        <div><span class="errata-new">The goal is to position for multiple possible futures...</span></div></div>
+        <div class="errata-diff-header">filler &rarr; cut</div>
+        <div class="errata-diff-content">
+          <div class="errata-block">
+            <span class="diff-removed">Turns out this isn't just a feeling. It's statistically measurable.</span>
+            <span class="diff-added">Turns out this is statistically measurable.</span>
+          </div>
+          <div class="errata-block">
+            <span class="diff-removed">Here's where it gets interesting. Each of these parallels...</span>
+            <span class="diff-added">Each of these parallels...</span>
+          </div>
+          <div class="errata-block">
+            <span class="diff-removed">This isn't just visual flourish &mdash; it's a direct representation of...</span>
+            <span class="diff-added">&mdash; a direct representation of...</span>
+          </div>
+          <div class="errata-block">
+            <span class="diff-removed">Acknowledging economic constraints isn't defeat. It's starting from reality...</span>
+            <span class="diff-added">Acknowledging economic constraints means starting from reality...</span>
+          </div>
+          <div class="errata-block">
+            <span class="diff-removed">The goal isn't to predict the future perfectly, but to position for multiple possible futures...</span>
+            <span class="diff-added">The goal is to position for multiple possible futures...</span>
+          </div>
+        </div>
       </div>
 
       <h3>The "isn't X, it's Y" pattern</h3>
@@ -111,12 +130,21 @@ extraStyles: |
         AI loves this construction. It sounds clever and says the same thing twice.
       </p>
       <div class="errata-diff">
-        <div class="errata-block"><div><span class="errata-old">it's not trying to be a manifesto. It's trying to be useful.</span></div>
-        <div><span class="errata-new">it's pragmatic rather than ideological.</span></div></div>
-        <div class="errata-block"><div><span class="errata-old">That's not hypocrisy &mdash; it's just the water we swim in.</span></div>
-        <div><span class="errata-new">Call it hypocrisy if you want &mdash; it's just the water we swim in.</span></div></div>
-        <div class="errata-block"><div><span class="errata-old">This isn't about AI dependency or replacement of human capability. It's about specific cognitive patterns...</span></div>
-        <div><span class="errata-new">The key factor is specific cognitive patterns...</span></div></div>
+        <div class="errata-diff-header">pattern removal</div>
+        <div class="errata-diff-content">
+          <div class="errata-block">
+            <span class="diff-removed">it's not trying to be a manifesto. It's trying to be useful.</span>
+            <span class="diff-added">it's pragmatic rather than ideological.</span>
+          </div>
+          <div class="errata-block">
+            <span class="diff-removed">That's not hypocrisy &mdash; it's just the water we swim in.</span>
+            <span class="diff-added">Call it hypocrisy if you want &mdash; it's just the water we swim in.</span>
+          </div>
+          <div class="errata-block">
+            <span class="diff-removed">This isn't about AI dependency or replacement of human capability. It's about specific cognitive patterns...</span>
+            <span class="diff-added">The key factor is specific cognitive patterns...</span>
+          </div>
+        </div>
       </div>
 
       <h3>The "fascinating" problem</h3>
@@ -124,8 +152,11 @@ extraStyles: |
         If it's fascinating, the reader will figure that out. You don't need to announce it.
       </p>
       <div class="errata-diff">
-        <div><span class="errata-old">creates a fascinating strategic tension</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">creates a strategic tension</span></div>
-        <div><span class="errata-old">A remarkable periodic solution</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">A periodic solution</span></div>
+        <div class="errata-diff-header">adjective removal</div>
+        <div class="errata-diff-content">
+          <div><span class="errata-old">creates a fascinating strategic tension</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">creates a strategic tension</span></div>
+          <div><span class="errata-old">A remarkable periodic solution</span> <span class="errata-arrow">&rarr;</span> <span class="errata-new">A periodic solution</span></div>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
Extract all inline styles from errata.html into src/assets/css/errata.css,
following the same pattern as explore.css and home.css. Introduces semantic
class names (.errata-diff, .errata-old, .errata-new, .errata-arrow, etc.)
and loads the stylesheet via the extraStyles frontmatter hook.

https://claude.ai/code/session_011qsPT1VCiDNF2GCYNhjHuU